### PR TITLE
Update setup by upgrading torch version to >=1.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='afrolid',
       install_requires=[
           'tensorboardX==2.5.1',
           'regex',
-          'torch==1.11.0',
+          'torch>=1.13',
           'sentencepiece==0.1.96',
           'fairseq==0.12.2',
           'tqdm==4.63.0',


### PR DESCRIPTION
I have been getting this error when I try to !pip install afrolid. I think fairseq was updated  

ERROR: Cannot install afrolid==0.1.0 and fairseq==0.12.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    afrolid 0.1.0 depends on torch==1.11.0
    fairseq 0.12.2 depends on torch>=1.13

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict